### PR TITLE
Allow override $host,$port with env.{host,port} and Fix values calculation

### DIFF
--- a/elasticsearch_cache
+++ b/elasticsearch_cache
@@ -36,7 +36,7 @@ Tomas Doran (t0m) - c<< <bobtfish@bobtfish.net> >>
 
 =cut
 
-my $host = 'localhost';
+my $host = exists $ENV{'host'} ? $ENV{'host'} : 'localhost';
 
 my $ua = LWP::UserAgent->new;
 $ua->timeout(10);

--- a/elasticsearch_cache
+++ b/elasticsearch_cache
@@ -37,6 +37,7 @@ Tomas Doran (t0m) - c<< <bobtfish@bobtfish.net> >>
 =cut
 
 my $host = exists $ENV{'host'} ? $ENV{'host'} : 'localhost';
+my $port = exists $ENV{'port'} ? $ENV{'port'} : 9200;
 
 my $ua = LWP::UserAgent->new;
 $ua->timeout(10);
@@ -50,8 +51,8 @@ sub get_json_from_url {
     return $data;
 }
 
-my $data = get_json_from_url("http://$host:9200/_cluster/nodes");
-my $t_data = get_json_from_url("http://$host:9200/_cluster/nodes/stats");
+my $data = get_json_from_url("http://$host:$port/_cluster/nodes");
+my $t_data = get_json_from_url("http://$host:$port/_cluster/nodes/stats");
 my %out;
 
 foreach my $full_node_name (keys %{$data->{nodes}}) {

--- a/elasticsearch_cache
+++ b/elasticsearch_cache
@@ -53,13 +53,14 @@ sub get_json_from_url {
 
 my $data = get_json_from_url("http://$host:$port/_cluster/nodes");
 my $t_data = get_json_from_url("http://$host:$port/_cluster/nodes/stats");
-my %out;
+my %out = (field_size => 0, filter_size => 0);
 
 foreach my $full_node_name (keys %{$data->{nodes}}) {
     next unless $t_data->{nodes}{$full_node_name};
-    $out{field_size} = $t_data->{nodes}{$full_node_name}{indices}{cache}{field_size_in_bytes};
-    $out{filter_size} = $t_data->{nodes}{$full_node_name}{indices}{cache}{filter_size_in_bytes};
-
+    if (defined($t_data->{nodes}{$full_node_name}{indices}{cache})) {
+        $out{field_size} += $t_data->{nodes}{$full_node_name}{indices}{cache}{field_size_in_bytes};
+        $out{filter_size} += $t_data->{nodes}{$full_node_name}{indices}{cache}{filter_size_in_bytes};
+    }
 }
 if ($ARGV[0] and $ARGV[0] eq 'config') {
     print "graph_args --base 1024\n";

--- a/elasticsearch_cluster_shards
+++ b/elasticsearch_cluster_shards
@@ -36,7 +36,7 @@ Tomas Doran (t0m) - c<< <bobtfish@bobtfish.net> >>
 
 =cut
 
-my $host = 'localhost';
+my $host = exists $ENV{'host'} ? $ENV{'host'} : 'localhost';
 
 my $ua = LWP::UserAgent->new;
 $ua->timeout(10);

--- a/elasticsearch_cluster_shards
+++ b/elasticsearch_cluster_shards
@@ -37,6 +37,7 @@ Tomas Doran (t0m) - c<< <bobtfish@bobtfish.net> >>
 =cut
 
 my $host = exists $ENV{'host'} ? $ENV{'host'} : 'localhost';
+my $port = exists $ENV{'port'} ? $ENV{'port'} : 9200;
 
 my $ua = LWP::UserAgent->new;
 $ua->timeout(10);
@@ -50,7 +51,7 @@ sub get_json_from_url {
     return $data;
 }
 
-my $data = get_json_from_url("http://$host:9200/_cluster/health");
+my $data = get_json_from_url("http://$host:$port/_cluster/health");
 
 if ($ARGV[0] and $ARGV[0] eq 'config') {
     print "graph_title ElasticSearch cluster shards\n";

--- a/elasticsearch_docs
+++ b/elasticsearch_docs
@@ -36,7 +36,7 @@ Tomas Doran (t0m) - c<< <bobtfish@bobtfish.net> >>
 
 =cut
 
-my $host = 'localhost';
+my $host = exists $ENV{'host'} ? $ENV{'host'} : 'localhost';
 
 my $ua = LWP::UserAgent->new;
 $ua->timeout(10);

--- a/elasticsearch_docs
+++ b/elasticsearch_docs
@@ -37,6 +37,7 @@ Tomas Doran (t0m) - c<< <bobtfish@bobtfish.net> >>
 =cut
 
 my $host = exists $ENV{'host'} ? $ENV{'host'} : 'localhost';
+my $port = exists $ENV{'port'} ? $ENV{'port'} : 9200;
 
 my $ua = LWP::UserAgent->new;
 $ua->timeout(10);
@@ -50,8 +51,8 @@ sub get_json_from_url {
     return $data;
 }
 
-my $data = get_json_from_url("http://$host:9200/_cluster/nodes");
-my $t_data = get_json_from_url("http://$host:9200/_cluster/nodes/stats");
+my $data = get_json_from_url("http://$host:$port/_cluster/nodes");
+my $t_data = get_json_from_url("http://$host:$port/_cluster/nodes/stats");
 my %out;
 
 foreach my $full_node_name (keys %{$data->{nodes}}) {

--- a/elasticsearch_docs
+++ b/elasticsearch_docs
@@ -53,11 +53,11 @@ sub get_json_from_url {
 
 my $data = get_json_from_url("http://$host:$port/_cluster/nodes");
 my $t_data = get_json_from_url("http://$host:$port/_cluster/nodes/stats");
-my %out;
+my %out = (num_docs => 0);
 
 foreach my $full_node_name (keys %{$data->{nodes}}) {
     next unless $t_data->{nodes}{$full_node_name};
-    $out{num_docs} = $t_data->{nodes}{$full_node_name}{indices}{docs}{count};
+    $out{num_docs} += $t_data->{nodes}{$full_node_name}{indices}{docs}{count};
 }
 
 if ($ARGV[0] and $ARGV[0] eq 'config') {

--- a/elasticsearch_index_size
+++ b/elasticsearch_index_size
@@ -36,7 +36,7 @@ Tomas Doran (t0m) - c<< <bobtfish@bobtfish.net> >>
 
 =cut
 
-my $host = 'localhost';
+my $host = exists $ENV{'host'} ? $ENV{'host'} : 'localhost';
 
 my $ua = LWP::UserAgent->new;
 $ua->timeout(10);

--- a/elasticsearch_index_size
+++ b/elasticsearch_index_size
@@ -37,6 +37,7 @@ Tomas Doran (t0m) - c<< <bobtfish@bobtfish.net> >>
 =cut
 
 my $host = exists $ENV{'host'} ? $ENV{'host'} : 'localhost';
+my $port = exists $ENV{'port'} ? $ENV{'port'} : 9200;
 
 my $ua = LWP::UserAgent->new;
 $ua->timeout(10);
@@ -50,8 +51,8 @@ sub get_json_from_url {
     return $data;
 }
 
-my $data = get_json_from_url("http://$host:9200/_cluster/nodes");
-my $t_data = get_json_from_url("http://$host:9200/_cluster/nodes/stats");
+my $data = get_json_from_url("http://$host:$port/_cluster/nodes");
+my $t_data = get_json_from_url("http://$host:$port/_cluster/nodes/stats");
 my %out;
 
 foreach my $full_node_name (keys %{$data->{nodes}}) {

--- a/elasticsearch_index_size
+++ b/elasticsearch_index_size
@@ -53,11 +53,11 @@ sub get_json_from_url {
 
 my $data = get_json_from_url("http://$host:$port/_cluster/nodes");
 my $t_data = get_json_from_url("http://$host:$port/_cluster/nodes/stats");
-my %out;
+my %out = (index_size => 0);
 
 foreach my $full_node_name (keys %{$data->{nodes}}) {
     next unless $t_data->{nodes}{$full_node_name};
-    $out{index_size} = $t_data->{nodes}{$full_node_name}{indices}{store}{size_in_bytes};
+    $out{index_size} += $t_data->{nodes}{$full_node_name}{indices}{store}{size_in_bytes};
 }
 if ($ARGV[0] and $ARGV[0] eq 'config') {
     print "graph_args --base 1024\n";

--- a/elasticsearch_jvm_memory
+++ b/elasticsearch_jvm_memory
@@ -37,6 +37,7 @@ Tomas Doran (t0m) - c<< <bobtfish@bobtfish.net> >>
 =cut
 
 my $host = exists $ENV{'host'} ? $ENV{'host'} : 'localhost';
+my $port = exists $ENV{'port'} ? $ENV{'port'} : 9200;
 
 my $ua = LWP::UserAgent->new;
 $ua->timeout(10);
@@ -50,7 +51,7 @@ sub get_json_from_url {
     return $data;
 }
 
-my $data = get_json_from_url("http://$host:9200/_cluster/nodes?jvm=true");
+my $data = get_json_from_url("http://$host:$port/_cluster/nodes?jvm=true");
 my %out;
 
 foreach my $full_node_name (keys %{$data->{nodes}}) {

--- a/elasticsearch_jvm_memory
+++ b/elasticsearch_jvm_memory
@@ -36,7 +36,7 @@ Tomas Doran (t0m) - c<< <bobtfish@bobtfish.net> >>
 
 =cut
 
-my $host = 'localhost';
+my $host = exists $ENV{'host'} ? $ENV{'host'} : 'localhost';
 
 my $ua = LWP::UserAgent->new;
 $ua->timeout(10);

--- a/elasticsearch_jvm_memory
+++ b/elasticsearch_jvm_memory
@@ -52,12 +52,13 @@ sub get_json_from_url {
 }
 
 my $data = get_json_from_url("http://$host:$port/_cluster/nodes?jvm=true");
-my %out;
+my %out = (direct_max => 0, heap_init =>0, heap_max => 0, non_heap_init => 0, non_heap_max => 0);
 
 foreach my $full_node_name (keys %{$data->{nodes}}) {
+    next unless $data->{nodes}{$full_node_name};
     foreach my $name (grep { /_in_bytes$/ } keys %{ $data->{nodes}{$full_node_name}{jvm}{mem} }) {
         my ($dname) = $name =~ m/(.+)_in_bytes$/;
-        $out{$dname} = $data->{nodes}{$full_node_name}{jvm}{mem}{$name};
+        $out{$dname} += $data->{nodes}{$full_node_name}{jvm}{mem}{$name};
     }
 }
 if ($ARGV[0] and $ARGV[0] eq 'config') {

--- a/elasticsearch_jvm_threads
+++ b/elasticsearch_jvm_threads
@@ -36,7 +36,7 @@ Tomas Doran (t0m) - c<< <bobtfish@bobtfish.net> >>
 
 =cut
 
-my $host = 'localhost';
+my $host = exists $ENV{'host'} ? $ENV{'host'} : 'localhost';
 
 my $ua = LWP::UserAgent->new;
 $ua->timeout(10);

--- a/elasticsearch_jvm_threads
+++ b/elasticsearch_jvm_threads
@@ -37,6 +37,7 @@ Tomas Doran (t0m) - c<< <bobtfish@bobtfish.net> >>
 =cut
 
 my $host = exists $ENV{'host'} ? $ENV{'host'} : 'localhost';
+my $port = exists $ENV{'port'} ? $ENV{'port'} : 9200;
 
 my $ua = LWP::UserAgent->new;
 $ua->timeout(10);
@@ -50,8 +51,8 @@ sub get_json_from_url {
     return $data;
 }
 
-my $data = get_json_from_url("http://$host:9200/_cluster/nodes?jvm=true");
-my $t_data = get_json_from_url("http://$host:9200/_cluster/nodes/stats?jvm=true");
+my $data = get_json_from_url("http://$host:$port/_cluster/nodes?jvm=true");
+my $t_data = get_json_from_url("http://$host:$port/_cluster/nodes/stats?jvm=true");
 my %out;
 
 foreach my $full_node_name (keys %{$data->{nodes}}) {

--- a/elasticsearch_jvm_threads
+++ b/elasticsearch_jvm_threads
@@ -53,12 +53,12 @@ sub get_json_from_url {
 
 my $data = get_json_from_url("http://$host:$port/_cluster/nodes?jvm=true");
 my $t_data = get_json_from_url("http://$host:$port/_cluster/nodes/stats?jvm=true");
-my %out;
+my %out = (count => 0, peak_count => 0);
 
 foreach my $full_node_name (keys %{$data->{nodes}}) {
     next unless $t_data->{nodes}{$full_node_name};
     foreach my $name (keys %{ $t_data->{nodes}{$full_node_name}{jvm}{threads} }) {
-        $out{$name} = $t_data->{nodes}{$full_node_name}{jvm}{threads}{$name};
+        $out{$name} += $t_data->{nodes}{$full_node_name}{jvm}{threads}{$name};
     }
 }
 if ($ARGV[0] and $ARGV[0] eq 'config') {


### PR DESCRIPTION
$host and $port variables are hardcoded to 'localhost' and 9200

This commit allow to override these values.

```
# cat /etc/munin/plugin-conf.d/elasticsearch
[elasticsearch_*]
env.host x.x.x.x
env.port 9300
```

Values are wrong when having multi nodes. The last one is used.

```
"cluster_name": "elasticsearch", 
"nodes": {
    "1pZgzWkNTUqJsPfYcxH6qA": {
(...)
            "docs": {
                "count": 1221827, 
                "deleted": 0
            },
(...)
    "XU_9yAt0R-C6vyaK_iRVpw": {
(...)
            "docs": {
                "count": 0, 
                "deleted": 0
            },
```

Plugin return 0 instead of 1221827 + 0 = 1221827

Values in hash %out are not initialize to zero.
